### PR TITLE
creat_new_button

### DIFF
--- a/calculater.py
+++ b/calculater.py
@@ -25,36 +25,51 @@ class Main(QDialog):
         layout_equation_solution.addRow(label_equation, self.equation)
         layout_equation_solution.addRow(label_solution, self.solution)
 
-        ### 사칙연상 버튼 생성
+        ### 사칙연산 버튼 생성
         button_plus = QPushButton("+")
         button_minus = QPushButton("-")
         button_product = QPushButton("x")
         button_division = QPushButton("/")
+        button_share = QPushButton("%")
+        button_root = QPushButton("x^(1/2)")
+        button_square = QPushButton("x^2")
+        button_reciprocal = QPushButton("1/x")
 
         ### 사칙연산 버튼을 클릭했을 때, 각 사칙연산 부호가 수식창에 추가될 수 있도록 시그널 설정
         button_plus.clicked.connect(lambda state, operation = "+": self.button_operation_clicked(operation))
         button_minus.clicked.connect(lambda state, operation = "-": self.button_operation_clicked(operation))
         button_product.clicked.connect(lambda state, operation = "*": self.button_operation_clicked(operation))
         button_division.clicked.connect(lambda state, operation = "/": self.button_operation_clicked(operation))
+        button_share.clicked.connect(lambda state, operation = "%": self.button_operation_clicked(operation))
+        button_root.clicked.connect(lambda state, operation = "%": self.button_operation_clicked(operation))
+        button_square.clicked.connect(lambda state, operation = "%": self.button_operation_clicked(operation))
+        button_reciprocal.clicked.connect(lambda state, operation = "%": self.button_operation_clicked(operation))
 
         ### 사칙연산 버튼을 layout_operation 레이아웃에 추가
         layout_operation.addWidget(button_plus)
         layout_operation.addWidget(button_minus)
         layout_operation.addWidget(button_product)
         layout_operation.addWidget(button_division)
+        layout_operation.addWidget(button_share)
+        layout_operation.addWidget(button_root)
+        layout_operation.addWidget(button_square)
+        layout_operation.addWidget(button_reciprocal)
 
         ### =, clear, backspace 버튼 생성
         button_equal = QPushButton("=")
-        button_clear = QPushButton("Clear")
+        button_clear1 = QPushButton("C")
+        button_clear2 = QPushButton("CE")
         button_backspace = QPushButton("Backspace")
 
         ### =, clear, backspace 버튼 클릭 시 시그널 설정
         button_equal.clicked.connect(self.button_equal_clicked)
-        button_clear.clicked.connect(self.button_clear_clicked)
+        button_clear1.clicked.connect(self.button_clear_clicked)
+        button_clear2.clicked.connect(self.button_clear_clicked)
         button_backspace.clicked.connect(self.button_backspace_clicked)
 
         ### =, clear, backspace 버튼을 layout_clear_equal 레이아웃에 추가
-        layout_clear_equal.addWidget(button_clear)
+        layout_clear_equal.addWidget(button_clear1)
+        layout_clear_equal.addWidget(button_clear2)
         layout_clear_equal.addWidget(button_backspace)
         layout_clear_equal.addWidget(button_equal)
 


### PR DESCRIPTION
I add a new button for share, root, square, and reciprocal. I change the clear button name to C and CE.
C and CE buttons would operate the same as the previous clear button. I change the clear button name to C and CE because I have to make it looks similar to calculater in our computer.

나누기, 제곱근, 제곱, 역수 버튼을 만들었습니다.
기존의 clear 버튼이었던 것을 기존 계산기와 버튼의 모습을 비슷하게하기 위해 동작은 같지만 C와 CE로 이름을 바꿔 만들었습니다.